### PR TITLE
Fixes conditional bug in the fullcalendar frontend module

### DIFF
--- a/src/Resources/contao/modules/ModuleFullcalendar.php
+++ b/src/Resources/contao/modules/ModuleFullcalendar.php
@@ -318,7 +318,7 @@ class ModuleFullcalendar extends EventsExt
 
                     // We take the "show from" time or the "event start" time to check the display duration limit
                     $displayStart = ($event['start']) ? $event['start'] : $event['startTime'];
-                    if (strlen($this->displayDuration) > 0) {
+                    if ($this->displayDuration > 0) {
                         $displayStop = strtotime($this->displayDuration, $displayStart);
                         if ($displayStop < $currTime) {
                             continue;


### PR DESCRIPTION
There is a bug in the fullcalendar module fetchEvents() function. The function checks if the displayDuration value length is bigger than 0. In fact that this property isn't configurable for this module palettes, this will result in no event results. 

I'm not sure, if this only relates to PHP >= v7.x..